### PR TITLE
Chapter class

### DIFF
--- a/src/interface.rs
+++ b/src/interface.rs
@@ -200,8 +200,8 @@ where
             Err(para) if self.mode.is_monologue() => {
                 let monologue = parse_body(para);
                 let mut html = Vec::new();
-                self.renderer.render_body(monologue, &mut html);
-                self.append_events(wrap_by_div_speech(html));
+                self.renderer.render_monologue(monologue, &mut html);
+                self.append_events(html);
             },
             Err(para) => {
                 let mut output = Vec::new();
@@ -266,14 +266,6 @@ fn wrap_by_paragraph_tag<'a>(events: Vec<Event<'a>>) -> Vec<Event<'a>> {
         events,
         Event::Start(Tag::Paragraph),
         Event::End(Tag::Paragraph),
-    )
-}
-
-fn wrap_by_div_speech<'a>(events: Vec<Event<'a>>) -> Vec<Event<'a>> {
-    wrap_events_by(
-        events,
-        Event::Html("<div class=\"speech\">".into()),
-        Event::Html("</div>".into()),
     )
 }
 

--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -98,16 +98,25 @@ impl Default for HtmlRenderer {
 }
 
 impl HtmlRenderer {
-    pub fn render_speech<'a>(&self, speech: Speech<'a>, events: &mut Vec<Event<'a>>) {
+    fn render_speech_begin<'a>(&self, events: &mut Vec<Event<'a>>) {
         let div_start = format!("<div class=\"{}\">", self.speech_classes.as_str());
-        let div_end = "</div>";
         
         events.push(Event::Html(div_start.into()));
+    }
+
+    fn render_speech_end<'a>(&self, events: &mut Vec<Event<'a>>) {
+        let div_end = "</div>";
+
+        events.push(Event::Html(div_end.into()));
+    }
+
+    pub fn render_speech<'a>(&self, speech: Speech<'a>, events: &mut Vec<Event<'a>>) {
+        self.render_speech_begin(events);
 
         self.render_heading(speech.heading, events);
         self.render_body(speech.body, events);
 
-        events.push(Event::Html(div_end.into()));
+        self.render_speech_end(events);
     }
 
     pub fn render_heading<'a>(&self, heading: Heading<'a>, events: &mut Vec<Event<'a>>) {

--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -17,7 +17,7 @@ fn encode_to_html_class(s: &str) -> String {
     let mut encoded = String::new();
 
     for c in s.chars() {
-        if c.is_ascii_alphanumeric() {
+        if c.is_ascii_alphanumeric() || c == '-' {
             encoded.push(c);
         } else {
             let mut buf = [0; 4];

--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -119,6 +119,12 @@ impl HtmlRenderer {
         self.render_speech_end(events);
     }
 
+    pub fn render_monologue<'a>(&self, body: Vec<Inline<'a>>, events: &mut Vec<Event<'a>>) {
+        self.render_speech_begin(events);
+        self.render_body(body, events);
+        self.render_speech_end(events);
+    }
+
     pub fn render_heading<'a>(&self, heading: Heading<'a>, events: &mut Vec<Event<'a>>) {
         let mut counter = self.heading_id_counter.borrow_mut();
 


### PR DESCRIPTION
Fix the following bugs:
- Hyphens in class name are escaped.
- `div.speech` which contains a monologue does not have custom class names.